### PR TITLE
Fixing config reader so that the host is read from swagger.api.host

### DIFF
--- a/app/play/modules/swagger/ApiListingCache.scala
+++ b/app/play/modules/swagger/ApiListingCache.scala
@@ -27,7 +27,7 @@ object ApiListingCache {
       cache = Some(swagger)
       cache
     }
-    cache.get.setHost(host)
+
     cache
   }
 }


### PR DESCRIPTION
Fixing config reader so that the host is read from swagger.api.host

The value in the config file was being ignored and instead was being read from the request object.
