### PR TITLE
Fixing error where not declaring swagger.api.host

### DIFF
--- a/app/play/modules/swagger/SwaggerPlugin.scala
+++ b/app/play/modules/swagger/SwaggerPlugin.scala
@@ -54,7 +54,7 @@ class SwaggerPluginImpl @Inject()(lifecycle: ApplicationLifecycle,
 
   val host = config.getString("swagger.api.host")
     .filter(host => !host.isEmpty)
-    .getOrElse("localhost:9000")
+    .orNull
 
   val title = config.getString("swagger.api.info.title") match {
     case None => ""


### PR DESCRIPTION
...will result the plugging defaulting to localhost:9000, instead of correctly using location.host to determine the current host. This can cause issues if play does not use port 9000 or it is deployed to a remote server.
